### PR TITLE
Generate executable jars

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,87 @@
           </execution>
         </executions>
       </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <id>server</id>
+            <configuration>
+              <archive>
+                <manifest>
+                  <mainClass>com.Elessar.app.ServerMain</mainClass>
+                </manifest>
+              </archive>
+              <descriptorRefs>
+                <descriptorRef>jar-with-dependencies</descriptorRef>
+              </descriptorRefs>
+              <finalName>mini-wechat-server</finalName>
+            </configuration>
+          </execution>
+	  <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <id>client-console</id>
+            <configuration>
+              <archive>
+                <manifest>
+                  <mainClass>com.Elessar.app.ClientMain</mainClass>
+                </manifest>
+              </archive>
+              <descriptorRefs>
+                <descriptorRef>jar-with-dependencies</descriptorRef>
+              </descriptorRefs>
+              <finalName>mini-wechat-client-console</finalName>
+            </configuration>
+          </execution>
+	  <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <id>perftest-main</id>
+            <configuration>
+              <archive>
+                <manifest>
+                  <mainClass>com.Elessar.app.PerfTestMain</mainClass>
+                </manifest>
+              </archive>
+              <descriptorRefs>
+                <descriptorRef>jar-with-dependencies</descriptorRef>
+              </descriptorRefs>
+              <finalName>mini-wechat-perftest</finalName>
+            </configuration>
+          </execution>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <id>client</id>
+            <configuration>
+              <archive>
+                <manifest>
+                  <mainClass>com.Elessar.app.SetupClientMain</mainClass>
+                </manifest>
+              </archive>
+              <descriptorRefs>
+                <descriptorRef>jar-with-dependencies</descriptorRef>
+              </descriptorRefs>
+              <finalName>mini-wechat-client</finalName>
+            </configuration>
+          </execution>
+
+        </executions>
+      </plugin>
+
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
Generate jars that can be run directly without invoking maven. We can run them like:
java -jar target/mini-wechat-client-console-jar-with-dependencies.jar localhost 9000 6000